### PR TITLE
Fix no state machine with the name 'default' defined

### DIFF
--- a/lib/rails_admin_aasm/field.rb
+++ b/lib/rails_admin_aasm/field.rb
@@ -111,7 +111,7 @@ module RailsAdmin
           end
 
           register_instance_option :state_machine_name do
-            @state_machine_name || :default
+            @state_machine_name || name
           end
         end
       end


### PR DESCRIPTION
I have this error when I use this gem.

```
There is no state machine with the name 'default' defined in <Model>!
```

This error is caused from this method:

``` ruby
register_instance_option :state_machine_name do
  @state_machine_name || :default
end
```

By change `:default` to `name` the error has been fixed.

Thank you.
